### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 # Setup copied from q2-emperor
 setup(
-    name="metnet",
+    name="q2-metnet",
     version="2023.0.1",
     packages=find_packages(),
     author="Francesco Balzerani, Telmo Blasco, Luis Vitores Valcarcel, Francisco J. Planes",


### PR DESCRIPTION
@cjrodriguez98 apologies for any inconvenience, but there is one more thing I didn't notice last time to do with the name of the name of the package. The install instruction in the environment file looks like the following:

https://github.com/PlanesLab/q2-metnet/blob/12d5ef881914f8118d6714847c37da11a6e0a494/environment-files/q2-metnet-qiime2-amplicon-2024.10.yml#L9

This is parsed as:

```
{name-of-package-to-install}@{source-to-install-package-from}
```

That package name has to match the name of the package indicated in setup.py